### PR TITLE
make it compatible with CAPA v2.0.0.

### DIFF
--- a/capa_explorer_plugin/cutterplugin.py
+++ b/capa_explorer_plugin/cutterplugin.py
@@ -185,14 +185,24 @@ class MyDockWidget(cutter.CutterDockWidget):
                 continue
 
             for attack in rule["meta"]["att&ck"]:
+                if isinstance(attack,dict):
+                    tactic = attack.get("tactic")
+                    technique = attack.get("technique")
+                    subtechnique = attack.get("subtechnique")
+                    id = attack.get("id")
+                    if subtechnique=="":
+                        tactics[tactic].add((technique, id))
+                    else:
+                        tactics[tactic].add((technique, subtechnique, id))
+                    continue
                 tactic, _, rest = attack.partition("::")
-            if "::" in rest:
-                technique, _, rest = rest.partition("::")
-                subtechnique, _, id = rest.rpartition(" ")
-                tactics[tactic].add((technique, subtechnique, id))
-            else:
-                technique, _, id = rest.rpartition(" ")
-                tactics[tactic].add((technique, id))
+                if "::" in rest:
+                    technique, _, rest = rest.partition("::")
+                    subtechnique, _, id = rest.rpartition(" ")
+                    tactics[tactic].add((technique, subtechnique, id))
+                else:
+                    technique, _, id = rest.rpartition(" ")
+                    tactics[tactic].add((technique, id))
         
         column_one = []
         column_two = []

--- a/capa_explorer_plugin/model.py
+++ b/capa_explorer_plugin/model.py
@@ -5,17 +5,15 @@ import re
 from .item import (
     CapaExplorerDataItem,
     CapaExplorerRuleItem,
-    CapaExplorerFunctionItem,
     CapaExplorerBlockItem,
-    CapaExplorerSubscopeItem,
     CapaExplorerDefaultItem,
     CapaExplorerFeatureItem,
     CapaExplorerByteViewItem,
-    CapaExplorerInstructionViewItem,
+    CapaExplorerFunctionItem,
+    CapaExplorerSubscopeItem,
+    CapaExplorerRuleMatchItem,
     CapaExplorerStringViewItem,
-    CapaExplorerRuleMatchItem
-    
-
+    CapaExplorerInstructionViewItem,
 )
 from . import util, capa_constants
 
@@ -509,7 +507,16 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
             )
 
         if feature["type"] == "regex":
-            return CapaExplorerStringViewItem(parent, display, location, feature["match"])
+            if feature.get("match"):
+                return CapaExplorerStringViewItem(parent, display, location, feature["match"])
+            for s, locations in feature["matches"].items():
+                if location in locations:
+                    return CapaExplorerStringViewItem(
+                        parent, display, location, '"' + util.escape_string(s) + '"'
+                    )
+
+            # programming error: the given location should always be found in the regex matches
+            raise ValueError("regex match at location not found")
 
         if feature["type"] == "basicblock":
             return CapaExplorerBlockItem(parent, location)

--- a/capa_explorer_plugin/util.py
+++ b/capa_explorer_plugin/util.py
@@ -138,3 +138,17 @@ def capability_rules(doc):
             continue
 
         yield rule
+
+
+def escape_string(s: str) -> str:
+    """escape special characters"""
+    s = repr(s)
+    if not s.startswith(('"', "'")):
+        # u'hello\r\nworld' -> hello\\r\\nworld
+        s = s[2:-1]
+    else:
+        # 'hello\r\nworld' -> hello\\r\\nworld
+        s = s[1:-1]
+    s = s.replace("\\'", "'")  # repr() may escape "'" in some edge cases, remove
+    s = s.replace('"', '\\"')  # repr() does not escape '"', add
+    return s


### PR DESCRIPTION
cause by breaking changes:
json: results document now contains parsed ATT&CK and MBC fields instead of canonical representation #526 @mr-tz
json: record all matching strings for regex #159 @williballenthin